### PR TITLE
Preventing errors when not using replicate command.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,4 +34,10 @@ aws_rds_instance_type            : "db.t2.micro"
 aws_rds_wait                     : "true"
 
 
+aws_rds_command                  : "create"
+
+
+# High wait timeout because RDS takes it's time.
+aws_rds_wait_timeout             : 900
+
 #aws_rds_vpc_subnet

--- a/tasks/rds.yml
+++ b/tasks/rds.yml
@@ -30,7 +30,7 @@
      port: "{{ aws_rds_port | default(omit) }}"
      iops: "{{ aws_rds_iops | default(omit) }}"
      character_set_name: "{{ aws_rds_character_set_name | default(omit) }}"
-  register: rds_server
+  register: rds_server_others
   when: aws_rds_command != 'replicate'
 
 
@@ -61,3 +61,9 @@
      character_set_name: "{{ aws_rds_character_set_name | default(omit) }}"
   register: rds_server
   when: aws_rds_command == 'replicate'
+
+- name: Set fact if command is not replicate
+  set_fact:
+     #  Overwrite rds_server variable with actual run result for later usage by other roles (e.g. aws-route53).
+     rds_server={{rds_server_others}}
+  when: aws_rds_command != 'replicate'


### PR DESCRIPTION
```
- Define 'create' as default command to use.
- Overwriting 'rds_server' variable with actual run result, so it is not having '"skip_reason": "Conditional check failed", "skipped": true"' as value.
- Set 'aws_rds_wait_timeout' to 15 minutes as default setting.
```
